### PR TITLE
Add check method

### DIFF
--- a/src/lib/Exception/Invalid.php
+++ b/src/lib/Exception/Invalid.php
@@ -2,7 +2,7 @@
 namespace CMPayments\Exception;
 
 
-class InvalidChecksum extends Invalid
+class Invalid extends \Exception
 {
 
 }

--- a/src/lib/Exception/InvalidChecksum.php
+++ b/src/lib/Exception/InvalidChecksum.php
@@ -1,0 +1,8 @@
+<?php
+namespace CMPayments\Exception;
+
+
+class InvalidChecksum extends \Exception
+{
+
+}

--- a/src/lib/Exception/InvalidCountry.php
+++ b/src/lib/Exception/InvalidCountry.php
@@ -1,0 +1,8 @@
+<?php
+namespace CMPayments\Exception;
+
+
+class InvalidCountry extends \Exception
+{
+
+}

--- a/src/lib/Exception/InvalidCountry.php
+++ b/src/lib/Exception/InvalidCountry.php
@@ -2,7 +2,7 @@
 namespace CMPayments\Exception;
 
 
-class InvalidCountry extends \Exception
+class InvalidCountry extends Invalid
 {
 
 }

--- a/src/lib/Exception/InvalidFormat.php
+++ b/src/lib/Exception/InvalidFormat.php
@@ -1,0 +1,8 @@
+<?php
+namespace CMPayments\Exception;
+
+
+class InvalidFormat extends \Exception
+{
+
+}

--- a/src/lib/Exception/InvalidFormat.php
+++ b/src/lib/Exception/InvalidFormat.php
@@ -2,7 +2,7 @@
 namespace CMPayments\Exception;
 
 
-class InvalidFormat extends \Exception
+class InvalidFormat extends Invalid
 {
 
 }

--- a/src/lib/Exception/InvalidLength.php
+++ b/src/lib/Exception/InvalidLength.php
@@ -2,7 +2,7 @@
 namespace CMPayments\Exception;
 
 
-class InvalidLength extends \Exception
+class InvalidLength extends Invalid
 {
 
 }

--- a/src/lib/Exception/InvalidLength.php
+++ b/src/lib/Exception/InvalidLength.php
@@ -1,0 +1,8 @@
+<?php
+namespace CMPayments\Exception;
+
+
+class InvalidLength extends \Exception
+{
+
+}

--- a/src/lib/IBAN.php
+++ b/src/lib/IBAN.php
@@ -15,7 +15,7 @@ use CMPayments\Exception\InvalidLength;
  * @package  IBAN
  * @author   Bas Peters <bp@cm.nl>
  *
- * @link     https://github.com/cmpayments/iban
+ * @link https://github.com/cmpayments/iban
  */
 
 class IBAN
@@ -155,6 +155,7 @@ class IBAN
 
     /**
      * Validate the supplied IBAN and throw exception when validation fails
+     *
      * @throws InvalidChecksum
      * @throws InvalidCountry
      * @throws InvalidFormat

--- a/src/lib/IBAN.php
+++ b/src/lib/IBAN.php
@@ -1,6 +1,10 @@
 <?php
 
 namespace CMPayments;
+use CMPayments\Exception\InvalidChecksum;
+use CMPayments\Exception\InvalidCountry;
+use CMPayments\Exception\InvalidFormat;
+use CMPayments\Exception\InvalidLength;
 
 /**
  * IBAN information and validation library
@@ -19,15 +23,15 @@ class IBAN
     /**
      * Semantic IBAN structure constants
      */
-    const COUNTRY_CODE_OFFSET             = 0;
-    const COUNTRY_CODE_LENGTH             = 2;
-    const CHECKSUM_OFFSET                 = 2;
-    const CHECKSUM_LENGTH                 = 2;
-    const ACCOUNT_IDENTIFICATION_OFFSET   = 4;
+    const COUNTRY_CODE_OFFSET = 0;
+    const COUNTRY_CODE_LENGTH = 2;
+    const CHECKSUM_OFFSET = 2;
+    const CHECKSUM_LENGTH = 2;
+    const ACCOUNT_IDENTIFICATION_OFFSET = 4;
     const INSTITUTE_IDENTIFICATION_OFFSET = 4;
     const INSTITUTE_IDENTIFICATION_LENGTH = 4;
-    const BANK_ACCOUNT_NUMBER_OFFSET      = 8;
-    const BANK_ACCOUNT_NUMBER_LENGTH      = 10;
+    const BANK_ACCOUNT_NUMBER_OFFSET = 8;
+    const BANK_ACCOUNT_NUMBER_LENGTH = 10;
 
     /**
      * @var array Country code to size, regex format for each country that supports IBAN
@@ -150,6 +154,32 @@ class IBAN
     }
 
     /**
+     * Validate the supplied IBAN and throw exception when validation fails
+     * @throws InvalidChecksum
+     * @throws InvalidCountry
+     * @throws InvalidFormat
+     * @throws InvalidLength
+     */
+    public function check()
+    {
+        if (!$this->isCountryCodeValid()) {
+            throw new InvalidCountry("IBAN ({$this->iban}) country code not valid or not supported");
+        }
+
+        if (!$this->isLengthValid()) {
+            throw new InvalidLength("IBAN ({$this->iban}) length is invalid");
+        }
+
+        if (!$this->isFormatValid()) {
+            throw new InvalidFormat("IBAN ({$this->iban}) format is invalid");
+        }
+
+        if (!$this->isChecksumValid()) {
+            throw new InvalidChecksum("IBAN ({$this->iban}) checksum is invalid");
+        }
+    }
+
+    /**
      * Validates the supplied IBAN and provides passthrough failure message when validation fails
      *
      * @param null $error passthrough variable
@@ -172,6 +202,14 @@ class IBAN
         }
 
         return false;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->format();
     }
 
     /**
@@ -240,6 +278,7 @@ class IBAN
     {
         return substr($this->iban, static::BANK_ACCOUNT_NUMBER_OFFSET, static::BANK_ACCOUNT_NUMBER_LENGTH);
     }
+
 
     /**
      * Validate IBAN length boundaries
@@ -334,9 +373,9 @@ class IBAN
         foreach (str_split($letterRepresentation) as $char) {
             $ord = ord($char);
             if ($ord >= 65 && $ord <= 90) {
-                $numericRepresentation .= (string) ($ord - 55);
+                $numericRepresentation .= (string)($ord - 55);
             } elseif ($ord >= 48 && $ord <= 57) {
-                $numericRepresentation .= (string) ($ord - 48);
+                $numericRepresentation .= (string)($ord - 48);
             }
         }
 

--- a/tests/IBANValidateTest.php
+++ b/tests/IBANValidateTest.php
@@ -117,17 +117,21 @@ class IBANValidateTest extends PHPUnit_Framework_TestCase
 
     public function provideValidIban()
     {
-        return array_map(function ($iban) {
-            return [new IBAN($iban)];
+        return array_map(
+            function ($iban) {
+                return [new IBAN($iban)];
 
-        }, require __DIR__ . '/data/ValidIbans.php');
+            }, include __DIR__ . '/data/ValidIbans.php'
+        );
     }
 
     public function provideInvalidIban()
     {
-        return array_map(function ($iban) {
-            return [new IBAN($iban)];
-        }, require(__DIR__ . '/data/InvalidIbans.php'));
+        return array_map(
+            function ($iban) {
+                return [new IBAN($iban)];
+            }, include __DIR__ . '/data/InvalidIbans.php'
+        );
     }
 
     public function provideSanitizeIban()

--- a/tests/IBANValidateTest.php
+++ b/tests/IBANValidateTest.php
@@ -119,14 +119,15 @@ class IBANValidateTest extends PHPUnit_Framework_TestCase
     {
         return array_map(function ($iban) {
             return [new IBAN($iban)];
-        }, require(__DIR__ . '/data/validIbans.php'));
+
+        }, require __DIR__ . '/data/ValidIbans.php');
     }
 
     public function provideInvalidIban()
     {
         return array_map(function ($iban) {
             return [new IBAN($iban)];
-        }, require(__DIR__ . '/data/invalidIbans.php'));
+        }, require(__DIR__ . '/data/InvalidIbans.php'));
     }
 
     public function provideSanitizeIban()

--- a/tests/IBANValidateTest.php
+++ b/tests/IBANValidateTest.php
@@ -7,63 +7,135 @@ use CMPayments\IBAN;
 
 class IBANValidateTest extends PHPUnit_Framework_TestCase
 {
-    const IBAN_TEST_NL = 'NL58ABNA0000000001';
-    const IBAN_TEST_SANITIZE1 = 'NL 58 ABNA 0000 0000 01';
-    const IBAN_TEST_SANITIZE2 = 'NL-58-ABNA-0000-0000-01';
-    const IBAN_TEST_SANITIZE3 = '{NL}[58](ABNA)<0000>"0000"`01`';
-    const IBAN_TEST_SANITIZE4 = '!@NL#$58%^ABNA&*0000;|0000,.01/:';
+    /**
+     * @var IBAN
+     */
+    private $iban;
 
-    public function testValidIbans()
+    public function setUp()
     {
-        $validIbans = require __DIR__ . '/data/ValidIbans.php';
-        foreach ($validIbans as $iban) {
-            $this->assertTrue((new IBAN($iban))->validate($error), "{$iban} => " . $error);
-        }
+        $this->iban = new IBAN('NL58ABNA0000000001');
     }
 
-    public function testInvalidIbans()
+    /**
+     * @param IBAN $iban
+     * @dataProvider provideValidIban
+     */
+    public function testIbanValidation(IBAN $iban)
     {
-        $invalidIbans = require __DIR__ . '/data/InvalidIbans.php';
-        foreach ($invalidIbans as $iban) {
-            $this->assertFalse((new IBAN($iban))->validate($error), "{$iban} should not be valid");
-        }
+        $this->assertTrue($iban->validate(), "{$iban} => validation failed");
     }
 
-    public function testIbanSanitation()
+    /**
+     * @param IBAN $iban
+     * @dataProvider provideInvalidIban
+     */
+    public function testIbanValidationFailed(IBAN $iban)
     {
-        $ibans = [
-            static::IBAN_TEST_SANITIZE1,
-            static::IBAN_TEST_SANITIZE2,
-            static::IBAN_TEST_SANITIZE3,
-            static::IBAN_TEST_SANITIZE4
-        ];
-        foreach ($ibans as $iban) {
-            $this->assertTrue((new IBAN($iban))->validate(), "{$iban} => failed to sanitize");
-        }
+        $this->assertFalse($iban->validate(), "{$iban} => validation failed");
+    }
+
+    /**
+     * @param IBAN $iban
+     * @dataProvider provideValidIban
+     */
+    public function testIbanCheck(IBAN $iban)
+    {
+        $this->assertNull($iban->check(), "{$iban} => check failed");
+    }
+
+    /**
+     * @expectedException \CMPayments\Exception\InvalidCountry
+     * @expectedExceptionMessage IBAN (BK561910000001234383) country code not valid or not supported
+     */
+    public function testIbanCheckInvalidCountry()
+    {
+        (new IBAN('BK561910000001234383'))->check();
+    }
+
+    /**
+     * @expectedException \CMPayments\Exception\InvalidLength
+     * @expectedExceptionMessage IBAN (AL472121100900000002356987410) length is invalid
+     */
+    public function testIbanCheckInvalidLength()
+    {
+        (new IBAN('AL472121100900000002356987410'))->check();
+    }
+
+    /**
+     * @expectedException \CMPayments\Exception\InvalidFormat
+     * @expectedExceptionMessage IBAN (CZA50800000K192000145399) format is invalid
+     */
+    public function testIbanCheckInvalidFormat()
+    {
+        (new IBAN('CZa50800000k192000145399'))->check();
+    }
+
+    /**
+     * @expectedException \CMPayments\Exception\InvalidChecksum
+     * @expectedExceptionMessage IBAN (AA00000000000000) checksum is invalid
+     */
+    public function testIbanCheckInvalidChecksum()
+    {
+
+        (new IBAN('AA00000000000000'))->check();
+    }
+
+    /**
+     * @dataProvider provideSanitizeIban
+     */
+    public function testIbanSanitation($iban)
+    {
+        $this->assertTrue((new IBAN($iban))->validate(), "{$iban} => failed to sanitize");
     }
 
     public function testGetCountryCode()
     {
-        $this->assertEquals('NL', (new IBAN(static::IBAN_TEST_NL))->getCountryCode());
+        $this->assertEquals('NL', $this->iban->getCountryCode());
     }
 
     public function testGetChecksum()
     {
-        $this->assertEquals('58', (new IBAN(static::IBAN_TEST_NL))->getChecksum());
+        $this->assertEquals('58', $this->iban->getChecksum());
     }
 
     public function testGetInstituteIdentification()
     {
-        $this->assertEquals('ABNA', (new IBAN(static::IBAN_TEST_NL))->getInstituteIdentification());
+        $this->assertEquals('ABNA', $this->iban->getInstituteIdentification());
     }
 
     public function testGetBankAccountNumber()
     {
-        $this->assertEquals('0000000001', (new IBAN(static::IBAN_TEST_NL))->getBankAccountNumber());
+        $this->assertEquals('0000000001', $this->iban->getBankAccountNumber());
     }
 
     public function testIbanFormatter()
     {
-        $this->assertEquals('NL58 ABNA 0000 0000 01', (new IBAN(static::IBAN_TEST_NL))->format());
+        $this->assertEquals('NL58 ABNA 0000 0000 01', $this->iban->format());
+    }
+
+
+    public function provideValidIban()
+    {
+        return array_map(function ($iban) {
+            return [new IBAN($iban)];
+        }, require(__DIR__ . '/data/validIbans.php'));
+    }
+
+    public function provideInvalidIban()
+    {
+        return array_map(function ($iban) {
+            return [new IBAN($iban)];
+        }, require(__DIR__ . '/data/invalidIbans.php'));
+    }
+
+    public function provideSanitizeIban()
+    {
+        return [
+            ['NL 58 ABNA 0000 0000 01'],
+            ['NL-58-ABNA-0000-0000-01'],
+            ['{NL}[58](ABNA)<0000>"0000"`01`'],
+            ['!@NL#$58%^ABNA&*0000;|0000,.01/:']
+        ];
     }
 }


### PR DESCRIPTION
I have added a check method which will allow the user of this library to avoid output arguments.

```php
$ibans = [...];

foreach ($ibans as $iban) {
  try {
    $iban->check();
  }  catch (\CMPayments\Exception\InvalidLength $e) {
  } catch (\CMPayments\Exception\Invalid $e) {
     // generic exception
  }
}

```